### PR TITLE
Enable and fix warnings

### DIFF
--- a/crypto-simple.cabal
+++ b/crypto-simple.cabal
@@ -22,6 +22,7 @@ library
                      , bytestring >= 0.10 && < 1
                      , cryptonite >= 0.19 && < 1
   default-language:    Haskell2010
+  ghc-options:         -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
 
 test-suite crypto-simple-test
   type:                exitcode-stdio-1.0
@@ -34,7 +35,7 @@ test-suite crypto-simple-test
                      , hspec
                      , QuickCheck
   other-modules:       Crypto.SimpleSpec
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
   default-language:    Haskell2010
 
 source-repository head

--- a/src/Crypto/Simple/CBC.hs
+++ b/src/Crypto/Simple/CBC.hs
@@ -2,7 +2,6 @@ module Crypto.Simple.CBC where
 
 import Data.Monoid ((<>))
 import Data.ByteString (ByteString)
-import Crypto.Cipher.AES (AES256)
 import Crypto.Cipher.Types (makeIV)
 import Crypto.Random.Entropy (getEntropy)
 import Crypto.Data.Padding (pad, unpad, Format(PKCS7))
@@ -16,14 +15,13 @@ encrypt key msg = do
     entropy <- getEntropy blockLength :: IO ByteString
     pure $ entropy <> (encrypt' CBCencrypt key' (makeIV entropy) msg')
   where
-    msg' = pad (PKCS7 blockLength) msg 
+    msg' = pad (PKCS7 blockLength) msg
     key' = if B.length key == 16 || B.length key == 32 then key else pad (PKCS7 blockLength) key
 
 
 -- | The key must be less than 32 bytes in length
 decrypt :: ByteString -> ByteString -> IO ByteString
 decrypt key msg = do
-    entropy <- getEntropy blockLength :: IO ByteString
     let msg'' = decrypt' CBCdecrypt key' (makeIV iv) msg'
     pure $ maybe msg'' id (unpad (PKCS7 blockLength) msg'')
   where

--- a/src/Crypto/Simple/CTR.hs
+++ b/src/Crypto/Simple/CTR.hs
@@ -2,7 +2,6 @@ module Crypto.Simple.CTR where
 
 import Data.Monoid ((<>))
 import Data.ByteString (ByteString)
-import Crypto.Cipher.AES (AES256)
 import Crypto.Cipher.Types (makeIV)
 import Crypto.Random.Entropy (getEntropy)
 import Crypto.Data.Padding (pad, Format(PKCS7))

--- a/src/Crypto/Simple/Cipher.hs
+++ b/src/Crypto/Simple/Cipher.hs
@@ -3,11 +3,8 @@ module Crypto.Simple.Cipher where
 import Data.Monoid ((<>))
 import Data.ByteString (ByteString)
 import Crypto.Cipher.AES (AES256)
-import Crypto.Random.Entropy (getEntropy)
 import Crypto.Cipher.Types (BlockCipher(..), Cipher(..), IV)
 import Crypto.Error (CryptoFailable(..))
-import qualified Data.ByteString as B
-
 
 newtype Key a = Key ByteString
     deriving (Show,Eq)

--- a/test/Crypto/SimpleSpec.hs
+++ b/test/Crypto/SimpleSpec.hs
@@ -2,12 +2,9 @@ module Crypto.SimpleSpec (main, spec) where
 
 import Test.Hspec
 import Test.QuickCheck
-import Test.QuickCheck.Monadic
+import Crypto.Simple.Cipher (maxKeyLength)
 import Data.ByteString (ByteString)
 import Data.ByteString.Char8 (pack)
-import Crypto.Simple.Cipher (blockLength, maxKeyLength)
-import Crypto.Random.Entropy (getEntropy)
-import qualified Data.ByteString as B
 import qualified Crypto.Simple.CTR as CTR
 import qualified Crypto.Simple.CBC as CBC
 
@@ -25,7 +22,7 @@ propNotSameMsg encrypt =
 
 propIsomorphic :: (ByteString -> ByteString -> IO ByteString)
                -> (ByteString -> ByteString -> IO ByteString) -> Property
-propIsomorphic encrypt decrypt = 
+propIsomorphic encrypt decrypt =
     forAll (arbitrary :: Gen String) $ \strMsg ->
     forAll (suchThat (arbitrary :: Gen String) (\s -> length s <= maxKeyLength)) $ \strKey -> ioProperty $ do
 
@@ -48,7 +45,7 @@ spec = do
         it "should not be the same as the original message (CTR)" $
             propNotSameMsg CTR.encrypt
 
-    describe "encrypt/decrypt" $ do 
+    describe "encrypt/decrypt" $ do
         it "should have an isomorphic relationship (CBC)" $
             propIsomorphic CBC.encrypt CBC.decrypt
         it "should have an isomorphic relationship (CTR)" $


### PR DESCRIPTION
Mostly doing this because I was puzzled that Crypto.Simple.CBC.decrypt was
getting entropy.